### PR TITLE
Abstract Snapshot meta data

### DIFF
--- a/src/Orleans.EventSourcing.Snapshot/SnapshotStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing.Snapshot/SnapshotStateWithMetaData.cs
@@ -44,8 +44,15 @@ namespace Orleans.EventSourcing.Snapshot
         }
     }
 
+    public interface ISnapshotMetaData
+    {
+    	public int SnapshotVersion { get; }
+	public int GlobalVersion { get; }
+	public DateTime? SnapshotUpdatedTime { get; }
+    }
+
     [Serializable]
-    public class SnapshotStateWithMetaData<TState, TEntry>
+    public class SnapshotStateWithMetaData<TState, TEntry> : ISnapshotMetaData
         where TState : class, new()
         where TEntry : class
     {

--- a/src/Orleans.EventSourcing.Snapshot/SnapshotStateWithMetaData.cs
+++ b/src/Orleans.EventSourcing.Snapshot/SnapshotStateWithMetaData.cs
@@ -46,9 +46,9 @@ namespace Orleans.EventSourcing.Snapshot
 
     public interface ISnapshotMetaData
     {
-    	public int SnapshotVersion { get; }
-	public int GlobalVersion { get; }
-	public DateTime? SnapshotUpdatedTime { get; }
+    	int SnapshotVersion { get; }
+	int GlobalVersion { get; }
+	DateTime? SnapshotUpdatedTime { get; }
     }
 
     [Serializable]


### PR DESCRIPTION
Allow casting and type matching without knowing the snapshot state or entry generics